### PR TITLE
switch case 缺少break导致注册中心节点变更时会重复调用 add update remove

### DIFF
--- a/netty-rpc-client/src/main/java/com/netty/rpc/client/discovery/ServiceDiscovery.java
+++ b/netty-rpc-client/src/main/java/com/netty/rpc/client/discovery/ServiceDiscovery.java
@@ -47,8 +47,10 @@ public class ServiceDiscovery {
                             break;
                         case CHILD_ADDED:
                             getServiceAndUpdateServer(childData, PathChildrenCacheEvent.Type.CHILD_ADDED);
+                            break;
                         case CHILD_UPDATED:
                             getServiceAndUpdateServer(childData, PathChildrenCacheEvent.Type.CHILD_UPDATED);
+                            break;
                         case CHILD_REMOVED:
                             getServiceAndUpdateServer(childData, PathChildrenCacheEvent.Type.CHILD_REMOVED);
                             break;


### PR DESCRIPTION
switch case中不加break会导致一连串后续case调用，望merge。