### PR TITLE
fix(RpcDecoder): remove redundent judgement

### DIFF
--- a/netty-rpc-common/src/main/java/com/netty/rpc/codec/RpcDecoder.java
+++ b/netty-rpc-common/src/main/java/com/netty/rpc/codec/RpcDecoder.java
@@ -26,15 +26,15 @@ public class RpcDecoder extends ByteToMessageDecoder {
 
     @Override
     public final void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
-        if (in.readableBytes() < 4) {
-            return;
-        }
-        in.markReaderIndex();
+//        if (in.readableBytes() < 4) {
+//            return;
+//        }
+//        in.markReaderIndex();
         int dataLength = in.readInt();
-        if (in.readableBytes() < dataLength) {
-            in.resetReaderIndex();
-            return;
-        }
+//        if (in.readableBytes() < dataLength) {
+//            in.resetReaderIndex();
+//            return;
+//        }
         byte[] data = new byte[dataLength];
         in.readBytes(data);
         Object obj = null;


### PR DESCRIPTION
LineFieldBasedFrameDecoder应该已经保证解码到一个完整的帧了，是不是在RpcDecoder中就不需要再进行帧是否完整的判断了？